### PR TITLE
bugfix: fix typo in dandelion.json

### DIFF
--- a/bundles/checkout-data-product-country-filter/codeception.yml
+++ b/bundles/checkout-data-product-country-filter/codeception.yml
@@ -1,4 +1,4 @@
-namespace: fond-of-kudu/checkout-rest-api-country-connector
+namespace: fond-of-kudu/checkout-data-product-country-filter
 
 suites:
   unit:

--- a/dandelion.json
+++ b/dandelion.json
@@ -3,11 +3,11 @@
   "pathToTempDirectory": "/home/dandelion/project/tmp/",
   "repositories": {
     "checkout-data-gift-cart-payment-country-filter": {
-      "path": "checkout-data-gift-cart-payment-country-filter",
+      "path": "bundles/checkout-data-gift-cart-payment-country-filter",
       "version": "1.0.0-alpha.0"
     },
     "checkout-data-product-country-filter": {
-      "path": "checkout-data-product-country-filter",
+      "path": "bundles/checkout-data-product-country-filter",
       "version": "1.0.0-alpha.0"
     },
     "checkout-rest-api-country-connector": {


### PR DESCRIPTION
**Changelog/Description**

A typo error in the dandelion.json file prevents the correct package-splitting in the GitHub workflow

- fix typo in dandelion.json
- fix typo in codeception.yml (checkout-data-product-country-filter)