### PR TITLE
chore: CaptureIsApprovedConditionPlugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,110 +1,68 @@
 zed:
-  - changed-files:
-      - any-glob-to-any-file:
-          - bundles/**/src/FondOfKudu/Zed/**
+  - bundles/**/src/FondOfKudu/Zed/**
 
 yves:
-  - changed-files:
-      - any-glob-to-any-file:
-          - bundles/**/src/FondOfKudu/Yves/**
+  - bundles/**/src/FondOfKudu/Yves/**
 
 glue:
-  - changed-files:
-      - any-glob-to-any-file:
-          - bundles/**/src/FondOfKudu/Glue/**
+  - bundles/**/src/FondOfKudu/Glue/**
 
 client:
-  - changed-files:
-      - any-glob-to-any-file:
-          - bundles/**/src/FondOfKudu/Client/**
+  - bundles/**/src/FondOfKudu/Client/**
 
 service:
-  - changed-files:
-      - any-glob-to-any-file:
-          - bundles/**/src/FondOfKudu/Service/**
+  - bundles/**/src/FondOfKudu/Service/**
 
 tests:
-  - changed-files:
-      - any-glob-to-any-file:
-          - bundles/**/tests/FondOfKudu/**
+  - bundles/**/tests/FondOfKudu/**
 
 composer:
-  - changed-files:
-      - any-glob-to-any-file:
-          - composer.json
-          - bundles/**/src/FondOfKudu/composer.json
+  - composer.json
+  - bundles/**/src/FondOfKudu/composer.json
 
 github:
-  - changed-files:
-      - any-glob-to-any-file:
-          - .github/**
+  - .github/**
 
 version:
-  - changed-files:
-      - any-glob-to-any-file:
-          - dandelion.json
+  - dandelion.json
 
 ### packages
 
 carts-rest-api:
-  - changed-files:
-      - any-glob-to-any-file:
-          - bundles/carts-rest-api/**
+  - bundles/carts-rest-api/**
 
 catalog-sort-price:
   - bundles/catalog-sort-price/**
 
 checkout-rest-api:
-  - changed-files:
-      - any-glob-to-any-file:
-          - bundles/checkout-rest-api/**
+  - bundles/checkout-rest-api/**
 
 checkout-rest-api-country-connector:
-  - changed-files:
-      - any-glob-to-any-file:
-          - bundles/checkout-rest-api-country-connector/**
+  - bundles/checkout-rest-api-country-connector/**
 
 checkout-rest-api-country-extension:
-  - changed-files:
-      - any-glob-to-any-file:
-          - bundles/checkout-rest-api-country-extension/**
+  - bundles/checkout-rest-api-country-extension/**
 
 product-image-storage-connector:
-  - changed-files:
-      - any-glob-to-any-file:
-          - bundles/product-image-storage-connector/**
+  - bundles/product-image-storage-connector/**
 
 quote:
-  - changed-files:
-      - any-glob-to-any-file:
-          - bundles/quote/**
+  - bundles/quote/**
 
 country-zipcode-restriction:
-  - changed-files:
-      - any-glob-to-any-file:
-          - country-zipcode-restriction/**
+  - country-zipcode-restriction/**
 
 checkout-data-product-country-filter:
-  - changed-files:
-      - any-glob-to-any-file:
-          - checkout-data-product-country-filter/**
+  - checkout-data-product-country-filter/**
 
 checkout-data-gift-cart-payment-country-filter:
-  - changed-files:
-      - any-glob-to-any-file:
-          - checkout-data-gift-cart-payment-country-filter/**
+  - checkout-data-gift-cart-payment-country-filter/**
 
 oms-order-confirmation:
-  - changed-files:
-      - any-glob-to-any-file:
-          - oms-order-confirmation/**
+  - oms-order-confirmation/**
 
 oms-payone-error:
-  - changed-files:
-      - any-glob-to-any-file:
-          - oms-payone-error/**
+  - oms-payone-error/**
 
 oms-retry-capture-process:
-  - changed-files:
-      - any-glob-to-any-file:
-          - oms-retry-capture-process/**
+  - oms-retry-capture-process/**

--- a/bundles/oms-retry-capture-process/composer.json
+++ b/bundles/oms-retry-capture-process/composer.json
@@ -10,7 +10,8 @@
   ],
   "require": {
     "php": ">=8.0",
-    "spryker/oms": ">= 8.0.0"
+    "spryker/oms": ">= 8.0.0",
+    "spryker-eco/payone": "^4.4.0"
   },
   "require-dev": {
     "fond-of-codeception/spryker": "*",

--- a/bundles/oms-retry-capture-process/src/FondOfKudu/Shared/OmsRetryCaptureProcess/OmsRetryCaptureProcessConstants.php
+++ b/bundles/oms-retry-capture-process/src/FondOfKudu/Shared/OmsRetryCaptureProcess/OmsRetryCaptureProcessConstants.php
@@ -8,4 +8,9 @@ interface OmsRetryCaptureProcessConstants
      * @var string
      */
     public const HOURS_AFTER_CAPTURE_FINAL_FAILED = 'OmsRetryCaptureProcess::HOURS_AFTER_CAPTURE_FINAL_FAILED';
+
+    /**
+     * @var string
+     */
+    public const CAPTURE_FAIL_TEST_RECIPIENTS = 'OmsRetryCaptureProcess::CAPTURE_FAIL_TEST_RECIPIENTS';
 }

--- a/bundles/oms-retry-capture-process/src/FondOfKudu/Shared/OmsRetryCaptureProcess/Transfer/oms_retry_capture_process.transfer.xml
+++ b/bundles/oms-retry-capture-process/src/FondOfKudu/Shared/OmsRetryCaptureProcess/Transfer/oms_retry_capture_process.transfer.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<transfers xmlns="spryker:transfer-01"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="spryker:transfer-01 http://static.spryker.com/transfer-01.xsd">
+
+    <transfer name="Order">
+        <property name="customer" type="Customer"/>
+    </transfer>
+
+    <transfer name="Customer">
+        <property name="email" type="string" />
+    </transfer>
+</transfers>

--- a/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/Communication/OmsRetryCaptureProcessCommunicationFactory.php
+++ b/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/Communication/OmsRetryCaptureProcessCommunicationFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace FondOfKudu\Zed\OmsRetryCaptureProcess\Communication;
+
+use FondOfKudu\Zed\OmsRetryCaptureProcess\Dependency\Facade\OmsRetryCaptureProcessFacadeToPayoneFacadeInterface;
+use FondOfKudu\Zed\OmsRetryCaptureProcess\OmsRetryCaptureProcessDependencyProvider;
+use Spryker\Zed\Kernel\Communication\AbstractCommunicationFactory;
+
+/**
+ * @method \FondOfKudu\Zed\OmsRetryCaptureProcess\OmsRetryCaptureProcessConfig getConfig()
+ */
+class OmsRetryCaptureProcessCommunicationFactory extends AbstractCommunicationFactory
+{
+    /**
+     * @return \FondOfKudu\Zed\OmsRetryCaptureProcess\Dependency\Facade\OmsRetryCaptureProcessFacadeToPayoneFacadeInterface
+     */
+    public function getPayoneFacade(): OmsRetryCaptureProcessFacadeToPayoneFacadeInterface
+    {
+        return $this->getProvidedDependency(OmsRetryCaptureProcessDependencyProvider::FACADE_PAYONE);
+    }
+}

--- a/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/Communication/Plugin/Condition/CaptureIsApprovedConditionPlugin.php
+++ b/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/Communication/Plugin/Condition/CaptureIsApprovedConditionPlugin.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace FondOfKudu\Zed\OmsRetryCaptureProcess\Communication\Plugin\Condition;
+
+use Generated\Shared\Transfer\OrderTransfer;
+use SprykerEco\Zed\Payone\Communication\Plugin\Oms\Condition\AbstractPlugin;
+
+/**
+ * @method \FondOfKudu\Zed\OmsRetryCaptureProcess\Communication\OmsRetryCaptureProcessCommunicationFactory getFactory()
+ * @method \FondOfKudu\Zed\OmsRetryCaptureProcess\OmsRetryCaptureProcessConfig getConfig()
+ */
+class CaptureIsApprovedConditionPlugin extends AbstractPlugin
+{
+    /**
+     * @var string
+     */
+    public const NAME = 'CaptureIsApprovedPlugin';
+
+    /**
+     * @param \Generated\Shared\Transfer\OrderTransfer $orderTransfer
+     *
+     * @return bool
+     */
+    protected function callFacade(OrderTransfer $orderTransfer): bool
+    {
+        if (in_array($orderTransfer->getCustomer()->getEmail(), $this->getConfig()->getCaptureFailTestRecipients())) {
+            return false;
+        }
+
+        return $this->getFactory()->getPayoneFacade()->isCaptureApproved($orderTransfer);
+    }
+}

--- a/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/Communication/Plugin/Condition/OrderCreatedInsideTimelimitConditionPlugin.php
+++ b/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/Communication/Plugin/Condition/OrderCreatedInsideTimelimitConditionPlugin.php
@@ -10,6 +10,7 @@ use Spryker\Zed\Oms\Dependency\Plugin\Condition\ConditionInterface;
 
 /**
  * @method \FondOfKudu\Zed\OmsRetryCaptureProcess\OmsRetryCaptureProcessConfig getConfig()
+ * @method \FondOfKudu\Zed\OmsRetryCaptureProcess\Communication\OmsRetryCaptureProcessCommunicationFactory getFactory()
  */
 class OrderCreatedInsideTimelimitConditionPlugin extends AbstractPlugin implements ConditionInterface
 {

--- a/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/Dependency/Facade/OmsRetryCaptureProcessFacadeToPayoneFacadeBridge.php
+++ b/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/Dependency/Facade/OmsRetryCaptureProcessFacadeToPayoneFacadeBridge.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace FondOfKudu\Zed\OmsRetryCaptureProcess\Dependency\Facade;
+
+use Generated\Shared\Transfer\OrderTransfer;
+use SprykerEco\Zed\Payone\Business\PayoneFacadeInterface;
+
+class OmsRetryCaptureProcessFacadeToPayoneFacadeBridge implements OmsRetryCaptureProcessFacadeToPayoneFacadeInterface
+{
+    private PayoneFacadeInterface $payoneFacade;
+
+    /**
+     * @param \SprykerEco\Zed\Payone\Business\PayoneFacadeInterface $payoneFacade
+     */
+    public function __construct(PayoneFacadeInterface $payoneFacade)
+    {
+        $this->payoneFacade = $payoneFacade;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\OrderTransfer $orderTransfer
+     *
+     * @return bool
+     */
+    public function isCaptureApproved(OrderTransfer $orderTransfer): bool
+    {
+        return $this->payoneFacade->isCaptureApproved($orderTransfer);
+    }
+}

--- a/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/Dependency/Facade/OmsRetryCaptureProcessFacadeToPayoneFacadeInterface.php
+++ b/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/Dependency/Facade/OmsRetryCaptureProcessFacadeToPayoneFacadeInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace FondOfKudu\Zed\OmsRetryCaptureProcess\Dependency\Facade;
+
+use Generated\Shared\Transfer\OrderTransfer;
+
+interface OmsRetryCaptureProcessFacadeToPayoneFacadeInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\OrderTransfer $orderTransfer
+     *
+     * @return bool
+     */
+    public function isCaptureApproved(OrderTransfer $orderTransfer): bool;
+}

--- a/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/OmsRetryCaptureProcessConfig.php
+++ b/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/OmsRetryCaptureProcessConfig.php
@@ -14,4 +14,12 @@ class OmsRetryCaptureProcessConfig extends AbstractBundleConfig
     {
         return $this->get(OmsRetryCaptureProcessConstants::HOURS_AFTER_CAPTURE_FINAL_FAILED, 12);
     }
+
+    /**
+     * @return array<string>
+     */
+    public function getCaptureFailTestRecipients(): array
+    {
+        return $this->get(OmsRetryCaptureProcessConstants::CAPTURE_FAIL_TEST_RECIPIENTS, ['capture-fail@fondof.de']);
+    }
 }

--- a/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/OmsRetryCaptureProcessDependencyProvider.php
+++ b/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/OmsRetryCaptureProcessDependencyProvider.php
@@ -2,18 +2,43 @@
 
 namespace FondOfKudu\Zed\OmsRetryCaptureProcess;
 
+use FondOfKudu\Zed\OmsRetryCaptureProcess\Dependency\Facade\OmsRetryCaptureProcessFacadeToPayoneFacadeBridge;
+use FondOfKudu\Zed\OmsRetryCaptureProcess\Dependency\Facade\OmsRetryCaptureProcessFacadeToPayoneFacadeInterface;
 use Spryker\Zed\Kernel\AbstractBundleDependencyProvider;
 use Spryker\Zed\Kernel\Container;
 
 class OmsRetryCaptureProcessDependencyProvider extends AbstractBundleDependencyProvider
 {
     /**
+     * @var string
+     */
+    public const FACADE_PAYONE = 'FACADE_PAYONE';
+
+    /**
      * @param \Spryker\Zed\Kernel\Container $container
      *
      * @return \Spryker\Zed\Kernel\Container
      */
-    public function provideBusinessLayerDependencies(Container $container): Container
+    public function provideCommunicationLayerDependencies(Container $container): Container
     {
+        $container = $this->addPayoneFacade($container);
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addPayoneFacade(Container $container): Container
+    {
+        $container[static::FACADE_PAYONE] = static fn (
+            Container $container
+        ): OmsRetryCaptureProcessFacadeToPayoneFacadeInterface => new OmsRetryCaptureProcessFacadeToPayoneFacadeBridge(
+            $container->getLocator()->payone()->facade(),
+        );
+
         return $container;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "spryker/product-storage-extension": "^1.0.0",
     "spryker/quote": "^2.0.0",
     "spryker/storage": "^3.20.0",
-    "spryker/synchronization": "^1.16"
+    "spryker/synchronization": "^1.16",
+    "spryker-eco/payone": "^4.4.0"
   },
   "require-dev": {
     "fond-of-codeception/spryker": "*",

--- a/dandelion.json
+++ b/dandelion.json
@@ -48,7 +48,7 @@
     },
     "oms-retry-capture-process": {
       "path": "bundles/oms-retry-capture-process",
-      "version": "1.0.0-alpha.0"
+      "version": "1.0.0"
     }
   },
   "vcs": {


### PR DESCRIPTION
**Changelog**

The plugin to move payments to the "capture failed" status has been moved from PYZ to the module. The corresponding email addresses can now be specified in the config.