### PR TITLE
chore: release version of oms-retry-capture-process

### DIFF
--- a/dandelion.json
+++ b/dandelion.json
@@ -48,7 +48,7 @@
     },
     "oms-retry-capture-process": {
       "path": "bundles/oms-retry-capture-process",
-      "version": "1.0.0-alpha.0"
+      "version": "1.0.0"
     }
   },
   "vcs": {


### PR DESCRIPTION
**Changelog/Description:**

- increase version to 1.0.0.