### PR TITLE
chore: payone capture retry, plugin issue fixed

### DIFF
--- a/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/Communication/Plugin/Condition/OrderCreatedInsideTimelimitConditionPlugin.php
+++ b/bundles/oms-retry-capture-process/src/FondOfKudu/Zed/OmsRetryCaptureProcess/Communication/Plugin/Condition/OrderCreatedInsideTimelimitConditionPlugin.php
@@ -22,11 +22,11 @@ class OrderCreatedInsideTimelimitConditionPlugin extends AbstractPlugin implemen
     {
         try {
             $createdAt = $orderItem->getOrder()->getCreatedAt();
-            $interval = $createdAt->diff(new DateTime());
+            $diff = round(((new DateTime())->getTimestamp() - $createdAt->getTimestamp()) / 3600);
         } catch (PropelException $e) {
             return false;
         }
 
-        return $interval->h > $this->getConfig()->getHoursAfterCaptureFinalFailed();
+        return $diff > $this->getConfig()->getHoursAfterCaptureFinalFailed();
     }
 }

--- a/bundles/oms-retry-capture-process/tests/FondOfKudu/Zed/OmsRetryCaptureProcess/Communication/Plugin/Condition/OrderCreatedInsideTimelimitConditionPluginTest.php
+++ b/bundles/oms-retry-capture-process/tests/FondOfKudu/Zed/OmsRetryCaptureProcess/Communication/Plugin/Condition/OrderCreatedInsideTimelimitConditionPluginTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Propel\Runtime\Exception\PropelException;
 use Spryker\Zed\Oms\Dependency\Plugin\Condition\ConditionInterface;
 
-class CaptureCircuitBreakerConditionPluginTest extends Unit
+class OrderCreatedInsideTimelimitConditionPluginTest extends Unit
 {
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|\Orm\Zed\Sales\Persistence\SpySalesOrderItem
@@ -61,7 +61,7 @@ class CaptureCircuitBreakerConditionPluginTest extends Unit
      */
     public function testCheckTrue(): void
     {
-        $createdAt = (new DateTime())->modify('+13 hours');
+        $createdAt = (new DateTime())->modify('-15 hours');
 
         $this->salesOrderItemMock->expects(static::atLeastOnce())
             ->method('getOrder')

--- a/bundles/oms-retry-capture-process/tests/FondOfKudu/Zed/OmsRetryCaptureProcess/OmsRetryCaptureProcessConfigTest.php
+++ b/bundles/oms-retry-capture-process/tests/FondOfKudu/Zed/OmsRetryCaptureProcess/OmsRetryCaptureProcessConfigTest.php
@@ -4,7 +4,7 @@ namespace FondOfKudu\Zed\OmsRetryCaptureProcess;
 
 use Codeception\Test\Unit;
 
-class OrderCreatedInsideTimelimitConditionPluginTest extends Unit
+class OmsRetryCaptureProcessConfigTest extends Unit
 {
     /**
      * @var \FondOfKudu\Zed\OmsRetryCaptureProcess\OmsRetryCaptureProcessConfig

--- a/dandelion.json
+++ b/dandelion.json
@@ -48,7 +48,7 @@
     },
     "oms-retry-capture-process": {
       "path": "bundles/oms-retry-capture-process",
-      "version": "1.0.0"
+      "version": "1.0.1"
     }
   },
   "vcs": {


### PR DESCRIPTION
**Changelog/Description**

There was an issue with the plugin when the difference between the two dates exceeds 24 hours. From that point on, DateInterval are calculating with days, for our case we need the difference in hours. Therefore, the calculation is now done manually based on the timestamps.