### PR TITLE
chore: product api schedule price import, create plugin

### DIFF
--- a/bundles/product-api-schedule-price-import/composer.json
+++ b/bundles/product-api-schedule-price-import/composer.json
@@ -10,9 +10,10 @@
   ],
   "require": {
     "php": ">=8.0",
+    "spryker/price-product": "^4.0.0",
+    "spryker/price-product-schedule": "^2.7.0",
     "spryker/product": "^6.0.0",
-    "spryker/product-extension": "^1.5.0",
-    "spryker/price-product-schedule": "^2.7.0"
+    "spryker/product-extension": "^1.5.0"
   },
   "require-dev": {
     "fond-of-codeception/spryker": "*",

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Shared/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportConstants.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Shared/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportConstants.php
@@ -55,4 +55,14 @@ interface ProductApiSchedulePriceImportConstants
      * @var string
      */
     public const SPECIAL_PRICE_TO = 'special_price_to';
+
+    /**
+     * @var string
+     */
+    public const ID_PRICE_PRODUCT_SCHEDULE_LIST = 'ID_PRICE_PRODUCT_SCHEDULE_LIST';
+
+    /**
+     * @var int
+     */
+    public const ID_PRICE_PRODUCT_SCHEDULE_LIST_DEFAULT_VALUE = 1;
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Shared/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportConstants.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Shared/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportConstants.php
@@ -25,8 +25,6 @@ interface ProductApiSchedulePriceImportConstants
     public const PRICE_DEFAULT = 'DEFAULT';
 
     /**
-     * @string
-     *
      * @var string
      */
     public const PRODUCT_ATTR_SPECIAL_PRICE = 'PRODUCT_ATTR_SPECIAL_PRICE';

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Shared/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportConstants.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Shared/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportConstants.php
@@ -23,4 +23,36 @@ interface ProductApiSchedulePriceImportConstants
      * @var string
      */
     public const PRICE_DEFAULT = 'DEFAULT';
+
+    /**
+     * @string
+     *
+     * @var string
+     */
+    public const PRODUCT_ATTR_SPECIAL_PRICE = 'PRODUCT_ATTR_SPECIAL_PRICE';
+
+    /**
+     * @var string
+     */
+    public const SPECIAL_PRICE = 'special_price';
+
+    /**
+     * @var string
+     */
+    public const PRODUCT_ATTR_SPECIAL_PRICE_FROM = 'PRODUCT_ATTR_SPECIAL_PRICE_FROM';
+
+    /**
+     * @var string
+     */
+    public const SPECIAL_PRICE_FROM = 'special_price_from';
+
+    /**
+     * @var string
+     */
+    public const PRODUCT_ATTR_SPECIAL_PRICE_TO = 'PRODUCT_ATTR_SPECIAL_PRICE_TO';
+
+    /**
+     * @var string
+     */
+    public const SPECIAL_PRICE_TO = 'special_price_to';
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Shared/ProductApiSchedulePriceImport/Transfer/product_api_schedule_price_import.transfer.xml
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Shared/ProductApiSchedulePriceImport/Transfer/product_api_schedule_price_import.transfer.xml
@@ -8,6 +8,7 @@
         <property name="isActive" type="bool"/>
         <property name="storeRelation" type="StoreRelation"/>
         <property name="searchMetadata" type="array" singular="searchMetadata" associative="true"/>
+        <property name="prices" type="PriceProduct[]" singular="price"/>
     </transfer>
 
     <transfer name="ProductConcrete">
@@ -24,6 +25,19 @@
         <property name="searchMetadata" type="array" singular="searchMetadata" associative="true"/>
     </transfer>
 
-    <transfer name="PriceProductSchedule"/>
+    <transfer name="PriceProduct">
+        <property name="moneyValue" type="MoneyValue"/>
+    </transfer>
+
+    <transfer name="MoneyValue">
+        <property name="currency" type="Currency"/>
+    </transfer>
+
+    <transfer name="PriceProductSchedule">
+        <property name="priceProduct" type="PriceProduct"/>
+    </transfer>
+
+    <transfer name="Currency"/>
+
     <transfer name="PriceProductScheduleResponse"/>
 </transfers>

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Shared/ProductApiSchedulePriceImport/Transfer/product_api_schedule_price_import.transfer.xml
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Shared/ProductApiSchedulePriceImport/Transfer/product_api_schedule_price_import.transfer.xml
@@ -27,17 +27,33 @@
 
     <transfer name="PriceProduct">
         <property name="moneyValue" type="MoneyValue"/>
+        <property name="priceType" type="PriceType"/>
+    </transfer>
+
+    <transfer name="PriceProductScheduleList">
+        <property name="idPriceProductScheduleList" type="int"/>
     </transfer>
 
     <transfer name="MoneyValue">
         <property name="currency" type="Currency"/>
+        <property name="grossAmount" type="int"/>
     </transfer>
 
     <transfer name="PriceProductSchedule">
+        <property name="priceProductScheduleList" type="PriceProductScheduleList"/>
+        <property name="activeFrom" type="string"/>
+        <property name="activeTo" type="string"/>
         <property name="priceProduct" type="PriceProduct"/>
+        <property name="store" type="Store"/>
+        <property name="currency" type="Currency"/>
+    </transfer>
+
+    <transfer name="StoreRelation">
+        <property name="stores" type="Store[]" singular="stores"/>
     </transfer>
 
     <transfer name="Currency"/>
-
+    <transfer name="Store"/>
     <transfer name="PriceProductScheduleResponse"/>
+    <transfer name="PriceType"/>
 </transfers>

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Shared/ProductApiSchedulePriceImport/Transfer/product_api_schedule_price_import.transfer.xml
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Shared/ProductApiSchedulePriceImport/Transfer/product_api_schedule_price_import.transfer.xml
@@ -23,4 +23,7 @@
         <property name="url" type="ProductUrl"/>
         <property name="searchMetadata" type="array" singular="searchMetadata" associative="true"/>
     </transfer>
+
+    <transfer name="PriceProductSchedule"/>
+    <transfer name="PriceProductScheduleResponse"/>
 </transfers>

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapper.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapper.php
@@ -60,9 +60,10 @@ class PriceProductScheduleMapper implements PriceProductScheduleMapperInterface
                 );
 
                 $priceProductTransfer->getMoneyValue()->setGrossAmount($specialPrice);
-                $priceProductScheduleTransfer->setStore($storeTransfer);
-                $priceProductScheduleTransfer->setPriceProduct($priceProductTransfer->setPriceType($priceTypeTransfer));
-                $priceProductScheduleTransfer->setCurrency($priceProductTransfer->getMoneyValue()->getCurrency());
+                $priceProductScheduleTransfer
+                    ->setStore($storeTransfer)
+                    ->setPriceProduct($priceProductTransfer->setPriceType($priceTypeTransfer))
+                    ->setCurrency($priceProductTransfer->getMoneyValue()->getCurrency());
 
                 $priceProductScheduleTransfers[] = $priceProductScheduleTransfer;
             }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapper.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapper.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper;
+
+use Generated\Shared\Transfer\PriceProductScheduleTransfer;
+use Generated\Shared\Transfer\ProductAbstractTransfer;
+
+class PriceProductScheduleMapper implements PriceProductScheduleMapperInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\ProductAbstractTransfer $productAbstractTransfer
+     *
+     * @return \Generated\Shared\Transfer\PriceProductScheduleTransfer
+     */
+    public function fromProductAbstractTransfer(
+        ProductAbstractTransfer $productAbstractTransfer
+    ): PriceProductScheduleTransfer {
+        $priceProductScheduleTransfer = new PriceProductScheduleTransfer();
+
+        return $priceProductScheduleTransfer;
+    }
+}

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapper.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapper.php
@@ -46,7 +46,7 @@ class PriceProductScheduleMapper implements PriceProductScheduleMapperInterface
         $priceProductScheduleTransfers = [];
 
         $priceProductScheduleListTransfer = (new PriceProductScheduleListTransfer())
-            ->setIdPriceProductScheduleList(1);
+            ->setIdPriceProductScheduleList($this->apiSchedulePriceImportConfig->getIdPriceProductScheduleList());
 
         $priceProductScheduleTransfer = (new PriceProductScheduleTransfer())
             ->setPriceProductScheduleList($priceProductScheduleListTransfer)
@@ -55,14 +55,12 @@ class PriceProductScheduleMapper implements PriceProductScheduleMapperInterface
 
         foreach ($productAbstractTransfer->getPrices() as $priceProductTransfer) {
             foreach ($productAbstractTransfer->getStoreRelation()->getStores() as $storeTransfer) {
-                $priceProductScheduleTransfer->setStore($storeTransfer);
-
                 $priceTypeTransfer = $this->priceProductFacade->findPriceTypeByName(
                     $this->apiSchedulePriceImportConfig->getPriceDimensionRrp(),
                 );
 
                 $priceProductTransfer->getMoneyValue()->setGrossAmount($specialPrice);
-
+                $priceProductScheduleTransfer->setStore($storeTransfer);
                 $priceProductScheduleTransfer->setPriceProduct($priceProductTransfer->setPriceType($priceTypeTransfer));
                 $priceProductScheduleTransfer->setCurrency($priceProductTransfer->getMoneyValue()->getCurrency());
 

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapper.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapper.php
@@ -2,6 +2,8 @@
 
 namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper;
 
+use FondOfKudu\Shared\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConstants;
+use Generated\Shared\Transfer\PriceProductScheduleListTransfer;
 use Generated\Shared\Transfer\PriceProductScheduleTransfer;
 use Generated\Shared\Transfer\ProductAbstractTransfer;
 
@@ -15,7 +17,28 @@ class PriceProductScheduleMapper implements PriceProductScheduleMapperInterface
     public function fromProductAbstractTransfer(
         ProductAbstractTransfer $productAbstractTransfer
     ): PriceProductScheduleTransfer {
+        $productAttributes = $productAbstractTransfer->getAttributes();
+        $specialPriceFrom = $productAttributes[ProductApiSchedulePriceImportConstants::PRODUCT_ATTR_SPECIAL_PRICE_FROM];
+        $specialPriceTo = $productAttributes[ProductApiSchedulePriceImportConstants::PRODUCT_ATTR_SPECIAL_PRICE_TO];
+
+        $priceProductScheduleListTransfer = (new PriceProductScheduleListTransfer())->setIdPriceProductScheduleList(1);
         $priceProductScheduleTransfer = new PriceProductScheduleTransfer();
+        $priceProductScheduleTransfer->setPriceProductScheduleList($priceProductScheduleListTransfer);
+        $priceProductScheduleTransfer->setActiveFrom($specialPriceFrom);
+        $priceProductScheduleTransfer->setActiveTo($specialPriceTo);
+
+        foreach ($productAbstractTransfer->getStoreRelation()->getStores() as $storeTransfer) {
+            $priceProductScheduleTransfer->setStore($storeTransfer);
+
+            break;
+        }
+
+        foreach ($productAbstractTransfer->getPrices() as $priceProductTransfer) {
+            $priceProductScheduleTransfer->setPriceProduct($priceProductTransfer);
+            $priceProductScheduleTransfer->setCurrency($priceProductTransfer->getMoneyValue()->getCurrency());
+
+            break;
+        }
 
         return $priceProductScheduleTransfer;
     }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapper.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapper.php
@@ -2,13 +2,26 @@
 
 namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper;
 
-use FondOfKudu\Shared\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConstants;
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConfig;
 use Generated\Shared\Transfer\PriceProductScheduleListTransfer;
 use Generated\Shared\Transfer\PriceProductScheduleTransfer;
 use Generated\Shared\Transfer\ProductAbstractTransfer;
 
 class PriceProductScheduleMapper implements PriceProductScheduleMapperInterface
 {
+    /**
+     * @var \FondOfKudu\Zed\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConfig
+     */
+    protected ProductApiSchedulePriceImportConfig $apiSchedulePriceImportConfig;
+
+    /**
+     * @param \FondOfKudu\Zed\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConfig $apiSchedulePriceImportConfig
+     */
+    public function __construct(ProductApiSchedulePriceImportConfig $apiSchedulePriceImportConfig)
+    {
+        $this->apiSchedulePriceImportConfig = $apiSchedulePriceImportConfig;
+    }
+
     /**
      * @param \Generated\Shared\Transfer\ProductAbstractTransfer $productAbstractTransfer
      *
@@ -18,8 +31,8 @@ class PriceProductScheduleMapper implements PriceProductScheduleMapperInterface
         ProductAbstractTransfer $productAbstractTransfer
     ): PriceProductScheduleTransfer {
         $productAttributes = $productAbstractTransfer->getAttributes();
-        $specialPriceFrom = $productAttributes[ProductApiSchedulePriceImportConstants::PRODUCT_ATTR_SPECIAL_PRICE_FROM];
-        $specialPriceTo = $productAttributes[ProductApiSchedulePriceImportConstants::PRODUCT_ATTR_SPECIAL_PRICE_TO];
+        $specialPriceFrom = $productAttributes[$this->apiSchedulePriceImportConfig->getProductAttributeSalePriceFrom()];
+        $specialPriceTo = $productAttributes[$this->apiSchedulePriceImportConfig->getProductAttributeSalePriceTo()];
 
         $priceProductScheduleListTransfer = (new PriceProductScheduleListTransfer())->setIdPriceProductScheduleList(1);
         $priceProductScheduleTransfer = new PriceProductScheduleTransfer();

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapperInterface.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapperInterface.php
@@ -2,7 +2,6 @@
 
 namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper;
 
-use Generated\Shared\Transfer\PriceProductScheduleTransfer;
 use Generated\Shared\Transfer\ProductAbstractTransfer;
 
 interface PriceProductScheduleMapperInterface
@@ -10,9 +9,7 @@ interface PriceProductScheduleMapperInterface
     /**
      * @param \Generated\Shared\Transfer\ProductAbstractTransfer $productAbstractTransfer
      *
-     * @return \Generated\Shared\Transfer\PriceProductScheduleTransfer
+     * @return array<\Generated\Shared\Transfer\PriceProductScheduleTransfer>
      */
-    public function fromProductAbstractTransfer(
-        ProductAbstractTransfer $productAbstractTransfer
-    ): PriceProductScheduleTransfer;
+    public function fromProductAbstractTransfer(ProductAbstractTransfer $productAbstractTransfer): array;
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapperInterface.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapperInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper;
+
+use Generated\Shared\Transfer\PriceProductScheduleTransfer;
+use Generated\Shared\Transfer\ProductAbstractTransfer;
+
+interface PriceProductScheduleMapperInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\ProductAbstractTransfer $productAbstractTransfer
+     *
+     * @return \Generated\Shared\Transfer\PriceProductScheduleTransfer
+     */
+    public function fromProductAbstractTransfer(
+        ProductAbstractTransfer $productAbstractTransfer
+    ): PriceProductScheduleTransfer;
+}

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Model/SalePriceProductAbstractCreator.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Model/SalePriceProductAbstractCreator.php
@@ -51,10 +51,14 @@ class SalePriceProductAbstractCreator implements SalePriceProductAbstractCreator
             return $productAbstractTransfer;
         }
 
-        $priceProductScheduleTransfer = $this->priceProductScheduleMapper->fromProductAbstractTransfer($productAbstractTransfer);
-        $this->priceProductScheduleFacade->createAndApplyPriceProductSchedule($priceProductScheduleTransfer);
+        $priceProductScheduleTransfers = $this->priceProductScheduleMapper
+            ->fromProductAbstractTransfer($productAbstractTransfer);
 
-         return $productAbstractTransfer;
+        foreach ($priceProductScheduleTransfers as $priceProductScheduleTransfer) {
+            $this->priceProductScheduleFacade->createAndApplyPriceProductSchedule($priceProductScheduleTransfer);
+        }
+
+        return $productAbstractTransfer;
     }
 
     /**

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Model/SalePriceProductAbstractCreator.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Model/SalePriceProductAbstractCreator.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Model;
+
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper\PriceProductScheduleMapperInterface;
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface;
+use Generated\Shared\Transfer\ProductAbstractTransfer;
+
+class SalePriceProductAbstractCreator implements SalePriceProductAbstractCreatorInterface
+{
+    /**
+     * @var \FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface
+     */
+    protected ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface $priceProductScheduleFacade;
+
+    /**
+     * @var \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper\PriceProductScheduleMapperInterface
+     */
+    protected PriceProductScheduleMapperInterface $priceProductScheduleMapper;
+
+    /**
+     * @param \FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface $priceProductScheduleFacade
+     * @param \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper\PriceProductScheduleMapperInterface $priceProductScheduleMapper
+     */
+    public function __construct(
+        ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface $priceProductScheduleFacade,
+        PriceProductScheduleMapperInterface $priceProductScheduleMapper
+    ) {
+        $this->priceProductScheduleFacade = $priceProductScheduleFacade;
+        $this->priceProductScheduleMapper = $priceProductScheduleMapper;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductAbstractTransfer $productAbstractTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductAbstractTransfer
+     */
+    public function createProductSchedulePriceByProductAbstractTransfer(
+        ProductAbstractTransfer $productAbstractTransfer
+    ): ProductAbstractTransfer {
+        $priceProductScheduleTransfer = $this->priceProductScheduleMapper->fromProductAbstractTransfer($productAbstractTransfer);
+        $this->priceProductScheduleFacade->createAndApplyPriceProductSchedule($priceProductScheduleTransfer);
+
+         return $productAbstractTransfer;
+    }
+}

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Model/SalePriceProductAbstractCreatorInterface.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Model/SalePriceProductAbstractCreatorInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Model;
+
+use Generated\Shared\Transfer\ProductAbstractTransfer;
+
+interface SalePriceProductAbstractCreatorInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\ProductAbstractTransfer $productAbstractTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductAbstractTransfer
+     */
+    public function createProductSchedulePriceByProductAbstractTransfer(
+        ProductAbstractTransfer $productAbstractTransfer
+    ): ProductAbstractTransfer;
+}

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportBusinessFacade.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportBusinessFacade.php
@@ -16,8 +16,22 @@ class ProductApiSchedulePriceImportBusinessFacade extends AbstractFacade impleme
      *
      * @return \Generated\Shared\Transfer\ProductAbstractTransfer
      */
-    public function persistProductAbstractSalePrice(ProductAbstractTransfer $productAbstractTransfer): ProductAbstractTransfer
-    {
+    public function createPriceProductAbstractSchedule(
+        ProductAbstractTransfer $productAbstractTransfer
+    ): ProductAbstractTransfer {
+        return $this->getFactory()
+            ->createSalePriceProductAbstractCreator()
+            ->createProductSchedulePriceByProductAbstractTransfer($productAbstractTransfer);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductAbstractTransfer $productAbstractTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductAbstractTransfer
+     */
+    public function updatePriceProductAbstractSchedule(
+        ProductAbstractTransfer $productAbstractTransfer
+    ): ProductAbstractTransfer {
         return $productAbstractTransfer;
     }
 
@@ -26,8 +40,20 @@ class ProductApiSchedulePriceImportBusinessFacade extends AbstractFacade impleme
      *
      * @return \Generated\Shared\Transfer\ProductConcreteTransfer
      */
-    public function persistProductConcreteSalePrice(ProductConcreteTransfer $productConcreteTransfer): ProductConcreteTransfer
-    {
+    public function createPriceProductConcreteSchedule(
+        ProductConcreteTransfer $productConcreteTransfer
+    ): ProductConcreteTransfer {
+        return $productConcreteTransfer;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductConcreteTransfer $productConcreteTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductConcreteTransfer
+     */
+    public function updatePriceProductConcreteSchedule(
+        ProductConcreteTransfer $productConcreteTransfer
+    ): ProductConcreteTransfer {
         return $productConcreteTransfer;
     }
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportBusinessFacadeInterface.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportBusinessFacadeInterface.php
@@ -12,7 +12,16 @@ interface ProductApiSchedulePriceImportBusinessFacadeInterface
      *
      * @return \Generated\Shared\Transfer\ProductAbstractTransfer
      */
-    public function persistProductAbstractSalePrice(
+    public function createPriceProductAbstractSchedule(
+        ProductAbstractTransfer $productAbstractTransfer
+    ): ProductAbstractTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductAbstractTransfer $productAbstractTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductAbstractTransfer
+     */
+    public function updatePriceProductAbstractSchedule(
         ProductAbstractTransfer $productAbstractTransfer
     ): ProductAbstractTransfer;
 
@@ -21,7 +30,16 @@ interface ProductApiSchedulePriceImportBusinessFacadeInterface
      *
      * @return \Generated\Shared\Transfer\ProductConcreteTransfer
      */
-    public function persistProductConcreteSalePrice(
+    public function createPriceProductConcreteSchedule(
+        ProductConcreteTransfer $productConcreteTransfer
+    ): ProductConcreteTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductConcreteTransfer $productConcreteTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductConcreteTransfer
+     */
+    public function updatePriceProductConcreteSchedule(
         ProductConcreteTransfer $productConcreteTransfer
     ): ProductConcreteTransfer;
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportBusinessFactory.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportBusinessFactory.php
@@ -6,6 +6,7 @@ use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper\PriceProductSch
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper\PriceProductScheduleMapperInterface;
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Model\SalePriceProductAbstractCreator;
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Model\SalePriceProductAbstractCreatorInterface;
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToPriceProductFacadeInterface;
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface;
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportDependencyProvider;
 use Spryker\Zed\Kernel\Business\AbstractBusinessFactory;
@@ -32,7 +33,10 @@ class ProductApiSchedulePriceImportBusinessFactory extends AbstractBusinessFacto
      */
     protected function createPriceProductScheduleMapper(): PriceProductScheduleMapperInterface
     {
-        return new PriceProductScheduleMapper($this->getConfig());
+        return new PriceProductScheduleMapper(
+            $this->getPriceProductFacade(),
+            $this->getConfig(),
+        );
     }
 
     /**
@@ -41,5 +45,13 @@ class ProductApiSchedulePriceImportBusinessFactory extends AbstractBusinessFacto
     protected function getPriceProductScheduleFacade(): ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface
     {
         return $this->getProvidedDependency(ProductApiSchedulePriceImportDependencyProvider::FACADE_PRICE_PRODUCT_SCHEDULE);
+    }
+
+    /**
+     * @return \FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToPriceProductFacadeInterface
+     */
+    protected function getPriceProductFacade(): ProductApiSchedulePriceImportToPriceProductFacadeInterface
+    {
+        return $this->getProvidedDependency(ProductApiSchedulePriceImportDependencyProvider::FACADE_PRICE_PRODUCT);
     }
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportBusinessFactory.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportBusinessFactory.php
@@ -2,6 +2,12 @@
 
 namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business;
 
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper\PriceProductScheduleMapper;
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper\PriceProductScheduleMapperInterface;
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Model\SalePriceProductAbstractCreator;
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Model\SalePriceProductAbstractCreatorInterface;
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface;
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportDependencyProvider;
 use Spryker\Zed\Kernel\Business\AbstractBusinessFactory;
 
 /**
@@ -9,4 +15,30 @@ use Spryker\Zed\Kernel\Business\AbstractBusinessFactory;
  */
 class ProductApiSchedulePriceImportBusinessFactory extends AbstractBusinessFactory
 {
+    /**
+     * @return \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Model\SalePriceProductAbstractCreatorInterface
+     */
+    public function createSalePriceProductAbstractCreator(): SalePriceProductAbstractCreatorInterface
+    {
+        return new SalePriceProductAbstractCreator(
+            $this->getPriceProductScheduleFacade(),
+            $this->createPriceProductScheduleMapper(),
+        );
+    }
+
+    /**
+     * @return \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper\PriceProductScheduleMapperInterface
+     */
+    protected function createPriceProductScheduleMapper(): PriceProductScheduleMapperInterface
+    {
+        return new PriceProductScheduleMapper();
+    }
+
+    /**
+     * @return \FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface
+     */
+    protected function getPriceProductScheduleFacade(): ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface
+    {
+        return $this->getProvidedDependency(ProductApiSchedulePriceImportDependencyProvider::FACADE_PRICE_PRODUCT_SCHEDULE);
+    }
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportBusinessFactory.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportBusinessFactory.php
@@ -23,6 +23,7 @@ class ProductApiSchedulePriceImportBusinessFactory extends AbstractBusinessFacto
         return new SalePriceProductAbstractCreator(
             $this->getPriceProductScheduleFacade(),
             $this->createPriceProductScheduleMapper(),
+            $this->getConfig(),
         );
     }
 

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportBusinessFactory.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportBusinessFactory.php
@@ -32,7 +32,7 @@ class ProductApiSchedulePriceImportBusinessFactory extends AbstractBusinessFacto
      */
     protected function createPriceProductScheduleMapper(): PriceProductScheduleMapperInterface
     {
-        return new PriceProductScheduleMapper();
+        return new PriceProductScheduleMapper($this->getConfig());
     }
 
     /**

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportFacade.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportFacade.php
@@ -4,8 +4,12 @@ namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business;
 
 use Generated\Shared\Transfer\ProductAbstractTransfer;
 use Generated\Shared\Transfer\ProductConcreteTransfer;
+use Spryker\Zed\Kernel\Business\AbstractFacade;
 
-interface ProductApiSchedulePriceImportBusinessFacadeInterface
+/**
+ * @method \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\ProductApiSchedulePriceImportBusinessFactory getFactory()
+ */
+class ProductApiSchedulePriceImportFacade extends AbstractFacade implements ProductApiSchedulePriceImportFacadeInterface
 {
     /**
      * @param \Generated\Shared\Transfer\ProductAbstractTransfer $productAbstractTransfer
@@ -14,7 +18,11 @@ interface ProductApiSchedulePriceImportBusinessFacadeInterface
      */
     public function createPriceProductAbstractSchedule(
         ProductAbstractTransfer $productAbstractTransfer
-    ): ProductAbstractTransfer;
+    ): ProductAbstractTransfer {
+        return $this->getFactory()
+            ->createSalePriceProductAbstractCreator()
+            ->createProductSchedulePriceByProductAbstractTransfer($productAbstractTransfer);
+    }
 
     /**
      * @param \Generated\Shared\Transfer\ProductAbstractTransfer $productAbstractTransfer
@@ -23,7 +31,9 @@ interface ProductApiSchedulePriceImportBusinessFacadeInterface
      */
     public function updatePriceProductAbstractSchedule(
         ProductAbstractTransfer $productAbstractTransfer
-    ): ProductAbstractTransfer;
+    ): ProductAbstractTransfer {
+        return $productAbstractTransfer;
+    }
 
     /**
      * @param \Generated\Shared\Transfer\ProductConcreteTransfer $productConcreteTransfer
@@ -32,7 +42,9 @@ interface ProductApiSchedulePriceImportBusinessFacadeInterface
      */
     public function createPriceProductConcreteSchedule(
         ProductConcreteTransfer $productConcreteTransfer
-    ): ProductConcreteTransfer;
+    ): ProductConcreteTransfer {
+        return $productConcreteTransfer;
+    }
 
     /**
      * @param \Generated\Shared\Transfer\ProductConcreteTransfer $productConcreteTransfer
@@ -41,5 +53,7 @@ interface ProductApiSchedulePriceImportBusinessFacadeInterface
      */
     public function updatePriceProductConcreteSchedule(
         ProductConcreteTransfer $productConcreteTransfer
-    ): ProductConcreteTransfer;
+    ): ProductConcreteTransfer {
+        return $productConcreteTransfer;
+    }
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportFacadeInterface.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportFacadeInterface.php
@@ -4,12 +4,8 @@ namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business;
 
 use Generated\Shared\Transfer\ProductAbstractTransfer;
 use Generated\Shared\Transfer\ProductConcreteTransfer;
-use Spryker\Zed\Kernel\Business\AbstractFacade;
 
-/**
- * @method \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\ProductApiSchedulePriceImportBusinessFactory getFactory()
- */
-class ProductApiSchedulePriceImportBusinessFacade extends AbstractFacade implements ProductApiSchedulePriceImportBusinessFacadeInterface
+interface ProductApiSchedulePriceImportFacadeInterface
 {
     /**
      * @param \Generated\Shared\Transfer\ProductAbstractTransfer $productAbstractTransfer
@@ -18,11 +14,7 @@ class ProductApiSchedulePriceImportBusinessFacade extends AbstractFacade impleme
      */
     public function createPriceProductAbstractSchedule(
         ProductAbstractTransfer $productAbstractTransfer
-    ): ProductAbstractTransfer {
-        return $this->getFactory()
-            ->createSalePriceProductAbstractCreator()
-            ->createProductSchedulePriceByProductAbstractTransfer($productAbstractTransfer);
-    }
+    ): ProductAbstractTransfer;
 
     /**
      * @param \Generated\Shared\Transfer\ProductAbstractTransfer $productAbstractTransfer
@@ -31,9 +23,7 @@ class ProductApiSchedulePriceImportBusinessFacade extends AbstractFacade impleme
      */
     public function updatePriceProductAbstractSchedule(
         ProductAbstractTransfer $productAbstractTransfer
-    ): ProductAbstractTransfer {
-        return $productAbstractTransfer;
-    }
+    ): ProductAbstractTransfer;
 
     /**
      * @param \Generated\Shared\Transfer\ProductConcreteTransfer $productConcreteTransfer
@@ -42,9 +32,7 @@ class ProductApiSchedulePriceImportBusinessFacade extends AbstractFacade impleme
      */
     public function createPriceProductConcreteSchedule(
         ProductConcreteTransfer $productConcreteTransfer
-    ): ProductConcreteTransfer {
-        return $productConcreteTransfer;
-    }
+    ): ProductConcreteTransfer;
 
     /**
      * @param \Generated\Shared\Transfer\ProductConcreteTransfer $productConcreteTransfer
@@ -53,7 +41,5 @@ class ProductApiSchedulePriceImportBusinessFacade extends AbstractFacade impleme
      */
     public function updatePriceProductConcreteSchedule(
         ProductConcreteTransfer $productConcreteTransfer
-    ): ProductConcreteTransfer {
-        return $productConcreteTransfer;
-    }
+    ): ProductConcreteTransfer;
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductAbstractPostCreatePlugin.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductAbstractPostCreatePlugin.php
@@ -19,6 +19,6 @@ class SalePriceProductAbstractPostCreatePlugin extends AbstractPlugin implements
      */
     public function postCreate(ProductAbstractTransfer $productAbstractTransfer): ProductAbstractTransfer
     {
-        return $this->getFacade()->persistProductAbstractSalePrice($productAbstractTransfer);
+        return $this->getFacade()->createPriceProductAbstractSchedule($productAbstractTransfer);
     }
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductAbstractPostCreatePlugin.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductAbstractPostCreatePlugin.php
@@ -7,7 +7,7 @@ use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 use Spryker\Zed\ProductExtension\Dependency\Plugin\ProductAbstractPostCreatePluginInterface;
 
 /**
- * @method \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\ProductApiSchedulePriceImportBusinessFacadeInterface getFacade()
+ * @method \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\ProductApiSchedulePriceImportFacadeInterface getFacade()
  * @method \FondOfKudu\Zed\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConfig getConfig()
  */
 class SalePriceProductAbstractPostCreatePlugin extends AbstractPlugin implements ProductAbstractPostCreatePluginInterface

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductAbstractUpdatePlugin.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductAbstractUpdatePlugin.php
@@ -7,7 +7,7 @@ use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 use Spryker\Zed\Product\Dependency\Plugin\ProductAbstractPluginUpdateInterface;
 
 /**
- * @method \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\ProductApiSchedulePriceImportBusinessFacadeInterface getFacade()
+ * @method \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\ProductApiSchedulePriceImportFacadeInterface getFacade()
  * @method \FondOfKudu\Zed\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConfig getConfig()
  */
 class SalePriceProductAbstractUpdatePlugin extends AbstractPlugin implements ProductAbstractPluginUpdateInterface

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductAbstractUpdatePlugin.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductAbstractUpdatePlugin.php
@@ -19,6 +19,6 @@ class SalePriceProductAbstractUpdatePlugin extends AbstractPlugin implements Pro
      */
     public function update(ProductAbstractTransfer $productAbstractTransfer): ProductAbstractTransfer
     {
-        return $this->getFacade()->persistProductAbstractSalePrice($productAbstractTransfer);
+        return $this->getFacade()->updatePriceProductAbstractSchedule($productAbstractTransfer);
     }
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductConcreteCreatePlugin.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductConcreteCreatePlugin.php
@@ -19,6 +19,6 @@ class SalePriceProductConcreteCreatePlugin extends AbstractPlugin implements Pro
      */
     public function create(ProductConcreteTransfer $productConcreteTransfer): ProductConcreteTransfer
     {
-        return $this->getFacade()->persistProductConcreteSalePrice($productConcreteTransfer);
+        return $this->getFacade()->createPriceProductConcreteSchedule($productConcreteTransfer);
     }
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductConcreteCreatePlugin.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductConcreteCreatePlugin.php
@@ -7,7 +7,7 @@ use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 use Spryker\Zed\ProductExtension\Dependency\Plugin\ProductConcreteCreatePluginInterface;
 
 /**
- * @method \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\ProductApiSchedulePriceImportBusinessFacadeInterface getFacade()
+ * @method \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\ProductApiSchedulePriceImportFacadeInterface getFacade()
  * @method \FondOfKudu\Zed\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConfig getConfig()
  */
 class SalePriceProductConcreteCreatePlugin extends AbstractPlugin implements ProductConcreteCreatePluginInterface

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductConcreteUpdatePlugin.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductConcreteUpdatePlugin.php
@@ -19,6 +19,6 @@ class SalePriceProductConcreteUpdatePlugin extends AbstractPlugin implements Pro
      */
     public function update(ProductConcreteTransfer $productConcreteTransfer): ProductConcreteTransfer
     {
-        return $this->getFacade()->persistProductConcreteSalePrice($productConcreteTransfer);
+        return $this->getFacade()->updatePriceProductConcreteSchedule($productConcreteTransfer);
     }
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductConcreteUpdatePlugin.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Communication/Plugin/SalePriceProductConcreteUpdatePlugin.php
@@ -7,7 +7,7 @@ use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 use Spryker\Zed\Product\Dependency\Plugin\ProductConcretePluginUpdateInterface;
 
 /**
- * @method \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\ProductApiSchedulePriceImportBusinessFacadeInterface getFacade()
+ * @method \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\ProductApiSchedulePriceImportFacadeInterface getFacade()
  * @method \FondOfKudu\Zed\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConfig getConfig()
  */
 class SalePriceProductConcreteUpdatePlugin extends AbstractPlugin implements ProductConcretePluginUpdateInterface

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Dependency/Facade/ProductApiSchedulePriceImportToPriceProductFacadeBridge.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Dependency/Facade/ProductApiSchedulePriceImportToPriceProductFacadeBridge.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade;
+
+use Generated\Shared\Transfer\PriceTypeTransfer;
+use Spryker\Zed\PriceProduct\Business\PriceProductFacadeInterface;
+
+class ProductApiSchedulePriceImportToPriceProductFacadeBridge implements ProductApiSchedulePriceImportToPriceProductFacadeInterface
+{
+    /**
+     * @var \Spryker\Zed\PriceProduct\Business\PriceProductFacadeInterface
+     */
+    protected PriceProductFacadeInterface $priceProductFacade;
+
+    /**
+     * @param \Spryker\Zed\PriceProduct\Business\PriceProductFacadeInterface $priceProductFacade
+     */
+    public function __construct(PriceProductFacadeInterface $priceProductFacade)
+    {
+        $this->priceProductFacade = $priceProductFacade;
+    }
+
+    /**
+     * @param string $priceTypeName
+     *
+     * @return \Generated\Shared\Transfer\PriceTypeTransfer|null
+     */
+    public function findPriceTypeByName(string $priceTypeName): ?PriceTypeTransfer
+    {
+        return $this->priceProductFacade->findPriceTypeByName($priceTypeName);
+    }
+}

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Dependency/Facade/ProductApiSchedulePriceImportToPriceProductFacadeInterface.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Dependency/Facade/ProductApiSchedulePriceImportToPriceProductFacadeInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade;
+
+use Generated\Shared\Transfer\PriceTypeTransfer;
+
+interface ProductApiSchedulePriceImportToPriceProductFacadeInterface
+{
+    /**
+     * @param string $priceTypeName
+     *
+     * @return \Generated\Shared\Transfer\PriceTypeTransfer|null
+     */
+    public function findPriceTypeByName(string $priceTypeName): ?PriceTypeTransfer;
+}

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Dependency/Facade/ProductApiSchedulePriceImportToPriceProductScheduleFacadeBridge.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Dependency/Facade/ProductApiSchedulePriceImportToPriceProductScheduleFacadeBridge.php
@@ -2,6 +2,8 @@
 
 namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade;
 
+use Generated\Shared\Transfer\PriceProductScheduleResponseTransfer;
+use Generated\Shared\Transfer\PriceProductScheduleTransfer;
 use Spryker\Zed\PriceProductSchedule\Business\PriceProductScheduleFacadeInterface;
 
 class ProductApiSchedulePriceImportToPriceProductScheduleFacadeBridge implements ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface
@@ -17,5 +19,16 @@ class ProductApiSchedulePriceImportToPriceProductScheduleFacadeBridge implements
     public function __construct(PriceProductScheduleFacadeInterface $priceProductScheduleFacade)
     {
         $this->priceProductScheduleFacade = $priceProductScheduleFacade;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\PriceProductScheduleTransfer $priceProductScheduleTransfer
+     *
+     * @return \Generated\Shared\Transfer\PriceProductScheduleResponseTransfer
+     */
+    public function createAndApplyPriceProductSchedule(
+        PriceProductScheduleTransfer $priceProductScheduleTransfer
+    ): PriceProductScheduleResponseTransfer {
+        return $this->priceProductScheduleFacade->createAndApplyPriceProductSchedule($priceProductScheduleTransfer);
     }
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Dependency/Facade/ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Dependency/Facade/ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface.php
@@ -2,6 +2,17 @@
 
 namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade;
 
+use Generated\Shared\Transfer\PriceProductScheduleResponseTransfer;
+use Generated\Shared\Transfer\PriceProductScheduleTransfer;
+
 interface ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface
 {
+    /**
+     * @param \Generated\Shared\Transfer\PriceProductScheduleTransfer $priceProductScheduleTransfer
+     *
+     * @return \Generated\Shared\Transfer\PriceProductScheduleResponseTransfer
+     */
+    public function createAndApplyPriceProductSchedule(
+        PriceProductScheduleTransfer $priceProductScheduleTransfer
+    ): PriceProductScheduleResponseTransfer;
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportConfig.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportConfig.php
@@ -28,4 +28,37 @@ class ProductApiSchedulePriceImportConfig extends AbstractBundleConfig
             ProductApiSchedulePriceImportConstants::PRICE_DEFAULT,
         );
     }
+
+    /**
+     * @return string
+     */
+    public function getProductAttributeSalePrice(): string
+    {
+        return $this->get(
+            ProductApiSchedulePriceImportConstants::PRODUCT_ATTR_SPECIAL_PRICE,
+            ProductApiSchedulePriceImportConstants::SPECIAL_PRICE,
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getProductAttributeSalePriceFrom(): string
+    {
+        return $this->get(
+            ProductApiSchedulePriceImportConstants::PRODUCT_ATTR_SPECIAL_PRICE_FROM,
+            ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM,
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getProductAttributeSalePriceTo(): string
+    {
+        return $this->get(
+            ProductApiSchedulePriceImportConstants::PRODUCT_ATTR_SPECIAL_PRICE_TO,
+            ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO,
+        );
+    }
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportConfig.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportConfig.php
@@ -61,4 +61,15 @@ class ProductApiSchedulePriceImportConfig extends AbstractBundleConfig
             ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO,
         );
     }
+
+    /**
+     * @return int
+     */
+    public function getIdPriceProductScheduleList(): int
+    {
+        return $this->get(
+            ProductApiSchedulePriceImportConstants::ID_PRICE_PRODUCT_SCHEDULE_LIST,
+            ProductApiSchedulePriceImportConstants::ID_PRICE_PRODUCT_SCHEDULE_LIST_DEFAULT_VALUE,
+        );
+    }
 }

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportConfig.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportConfig.php
@@ -14,7 +14,7 @@ class ProductApiSchedulePriceImportConfig extends AbstractBundleConfig
     {
         return $this->get(
             ProductApiSchedulePriceImportConstants::PRICE_DIMENSION_RRP,
-            ProductApiSchedulePriceImportConstants::PRICE_ORIGINAL,
+            ProductApiSchedulePriceImportConstants::PRICE_DEFAULT,
         );
     }
 
@@ -25,7 +25,7 @@ class ProductApiSchedulePriceImportConfig extends AbstractBundleConfig
     {
         return $this->get(
             ProductApiSchedulePriceImportConstants::PRICE_DIMENSION_SALE,
-            ProductApiSchedulePriceImportConstants::PRICE_DEFAULT,
+            ProductApiSchedulePriceImportConstants::PRICE_ORIGINAL,
         );
     }
 

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportDependencyProvider.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportDependencyProvider.php
@@ -24,7 +24,10 @@ class ProductApiSchedulePriceImportDependencyProvider extends AbstractBundleDepe
      */
     public function provideBusinessLayerDependencies(Container $container): Container
     {
-        return parent::provideBusinessLayerDependencies($container);
+        $container = parent::provideBusinessLayerDependencies($container);
+        $container = $this->addPriceProductScheduleFacade($container);
+
+        return $container;
     }
 
     /**

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportDependencyProvider.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportDependencyProvider.php
@@ -2,6 +2,8 @@
 
 namespace FondOfKudu\Zed\ProductApiSchedulePriceImport;
 
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToPriceProductFacadeBridge;
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToPriceProductFacadeInterface;
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToPriceProductScheduleFacadeBridge;
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface;
 use Spryker\Zed\Kernel\AbstractBundleDependencyProvider;
@@ -16,6 +18,11 @@ class ProductApiSchedulePriceImportDependencyProvider extends AbstractBundleDepe
      * @var string
      */
     public const FACADE_PRICE_PRODUCT_SCHEDULE = 'FACADE_PRICE_PRODUCT_SCHEDULE';
+
+    /**
+     * @var string
+     */
+    public const FACADE_PRICE_PRODUCT = 'FACADE_PRICE_PRODUCT';
 
     /**
      * @param \Spryker\Zed\Kernel\Container $container
@@ -61,6 +68,22 @@ class ProductApiSchedulePriceImportDependencyProvider extends AbstractBundleDepe
             Container $container
         ): ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface => new ProductApiSchedulePriceImportToPriceProductScheduleFacadeBridge(
             $container->getLocator()->priceProductSchedule()->facade(),
+        );
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addPriceProductFacade(Container $container): Container
+    {
+        $container[static::FACADE_PRICE_PRODUCT] = static fn (
+            Container $container
+        ): ProductApiSchedulePriceImportToPriceProductFacadeInterface => new ProductApiSchedulePriceImportToPriceProductFacadeBridge(
+            $container->getLocator()->priceProduct()->facade(),
         );
 
         return $container;

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportDependencyProvider.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/ProductApiSchedulePriceImportDependencyProvider.php
@@ -32,6 +32,7 @@ class ProductApiSchedulePriceImportDependencyProvider extends AbstractBundleDepe
     public function provideBusinessLayerDependencies(Container $container): Container
     {
         $container = parent::provideBusinessLayerDependencies($container);
+        $container = $this->addPriceProductFacade($container);
         $container = $this->addPriceProductScheduleFacade($container);
 
         return $container;

--- a/bundles/product-api-schedule-price-import/tests/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapperTest.php
+++ b/bundles/product-api-schedule-price-import/tests/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Mapper/PriceProductScheduleMapperTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper;
+
+use Codeception\Test\Unit;
+
+class PriceProductScheduleMapperTest extends Unit
+{
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+    }
+}

--- a/bundles/product-api-schedule-price-import/tests/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Model/SalePriceProductAbstractCreatorTest.php
+++ b/bundles/product-api-schedule-price-import/tests/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Model/SalePriceProductAbstractCreatorTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Model;
+
+use Codeception\Test\Unit;
+
+class SalePriceProductAbstractCreatorTest extends Unit
+{
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+    }
+}

--- a/bundles/product-api-schedule-price-import/tests/FondOfKudu/Zed/ProductApiSchedulePriceImport/Dependency/Facade/ProductApiSchedulePriceImportToPriceProductFacadeBridgeTest.php
+++ b/bundles/product-api-schedule-price-import/tests/FondOfKudu/Zed/ProductApiSchedulePriceImport/Dependency/Facade/ProductApiSchedulePriceImportToPriceProductFacadeBridgeTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade;
+
+use Codeception\Test\Unit;
+
+class ProductApiSchedulePriceImportToPriceProductFacadeBridgeTest extends Unit
+{
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "spryker/locale": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "spryker/oms": ">= 8.0.0",
     "spryker/oms-extension": "^1.3",
+    "spryker/price-product": "^4.0.0",
     "spryker/price-product-schedule": "^2.7.0",
     "spryker/product": "^6.0.0",
     "spryker/product-extension": "^1.5.0",

--- a/dandelion.json
+++ b/dandelion.json
@@ -36,7 +36,7 @@
     },
     "product-api-schedule-price-import": {
       "path": "bundles/product-api-schedule-price-import",
-      "version": "1.0.0-alpha.0"
+      "version": "1.0.0-alpha.1"
     },
     "product-image-storage-connector": {
       "path": "bundles/product-image-storage-connector",


### PR DESCRIPTION
**Changelog/Description**

Since the pull request would become too large if I release all plugins, here's an interim status with the PostCreate plugin.

When creating a new product, the plugin checks whether the product attributes special_price, special_price_to, and special_price_from contain valid values. Based on these values, a new SchedulePrice is created for the newly created product. The ORIGINAL price is the RRP, and DEFAULT will be the Sale or Special Price in the future.

If everything is okay, I will provide the unit tests in the next step.

![image](https://github.com/fond-of-kudu/fond-of-kudu/assets/35733274/d596b2dd-7760-4795-a920-2f3dad04f263)
![image](https://github.com/fond-of-kudu/fond-of-kudu/assets/35733274/1c36503f-e9d5-40e1-8e06-898fe17ca112)


