### PR TITLE
chore: product api schedule price import

### DIFF
--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportBusinessFactory.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/ProductApiSchedulePriceImportBusinessFactory.php
@@ -6,6 +6,8 @@ use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper\PriceProductSch
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper\PriceProductScheduleMapperInterface;
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Model\SalePriceHandler;
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Model\SalePriceHandlerInterface;
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Validator\SpecialPriceAttributesValidator;
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Validator\SpecialPriceAttributesValidatorInterface;
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToCurrencyFacadeInterface;
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToPriceProductFacadeInterface;
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToPriceProductScheduleFacadeInterface;
@@ -29,6 +31,7 @@ class ProductApiSchedulePriceImportBusinessFactory extends AbstractBusinessFacto
             $this->getPriceProductScheduleFacade(),
             $this->getCurrencyFacade(),
             $this->getStoreFacade(),
+            $this->createSpecialPriceAttributesValidator(),
             $this->getRepository(),
             $this->getConfig(),
         );
@@ -45,6 +48,14 @@ class ProductApiSchedulePriceImportBusinessFactory extends AbstractBusinessFacto
             $this->getCurrencyFacade(),
             $this->getStoreFacade(),
         );
+    }
+
+    /**
+     * @return \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Validator\SpecialPriceAttributesValidatorInterface
+     */
+    protected function createSpecialPriceAttributesValidator(): SpecialPriceAttributesValidatorInterface
+    {
+        return new SpecialPriceAttributesValidator($this->getConfig());
     }
 
     /**

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Validator/SpecialPriceAttributesValidator.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Validator/SpecialPriceAttributesValidator.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Validator;
+
+use DateTime;
+use Exception;
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConfig;
+
+class SpecialPriceAttributesValidator implements SpecialPriceAttributesValidatorInterface
+{
+    /**
+     * @var \FondOfKudu\Zed\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConfig
+     */
+    protected ProductApiSchedulePriceImportConfig $config;
+
+    /**
+     * @param \FondOfKudu\Zed\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConfig $apiSchedulePriceImportConfig
+     */
+    public function __construct(ProductApiSchedulePriceImportConfig $apiSchedulePriceImportConfig)
+    {
+        $this->config = $apiSchedulePriceImportConfig;
+    }
+
+    /**
+     * @param array $productAttributes
+     *
+     * @return bool
+     */
+    public function validate(array $productAttributes): bool
+    {
+        if (!$this->validateSpecialPriceAttributes($productAttributes)) {
+            return false;
+        }
+
+        return $this->isSpecialPriceToInFuture($productAttributes[$this->config->getProductAttributeSalePriceTo()]);
+    }
+
+    /**
+     * @param array $productAttributes
+     *
+     * @return bool
+     */
+    protected function validateSpecialPriceAttributes(array $productAttributes): bool
+    {
+        $required = [
+            $this->config->getProductAttributeSalePrice(),
+            $this->config->getProductAttributeSalePriceFrom(),
+            $this->config->getProductAttributeSalePriceTo(),
+        ];
+
+        foreach ($required as $attribute) {
+            if (!isset($productAttributes[$attribute])) {
+                return false;
+            }
+
+            if (!$productAttributes[$attribute]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string $specialPriceTo
+     *
+     * @return bool
+     */
+    protected function isSpecialPriceToInFuture(string $specialPriceTo): bool
+    {
+        try {
+            $specialPriceTo = new DateTime($specialPriceTo);
+        } catch (Exception $exception) {
+            return false;
+        }
+
+        return $specialPriceTo >= new DateTime();
+    }
+}

--- a/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Validator/SpecialPriceAttributesValidatorInterface.php
+++ b/bundles/product-api-schedule-price-import/src/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Validator/SpecialPriceAttributesValidatorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Validator;
+
+interface SpecialPriceAttributesValidatorInterface
+{
+    /**
+     * @param array $productAttributes
+     *
+     * @return bool
+     */
+    public function validate(array $productAttributes): bool;
+}

--- a/bundles/product-api-schedule-price-import/tests/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Model/SalePriceHandlerTest.php
+++ b/bundles/product-api-schedule-price-import/tests/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Model/SalePriceHandlerTest.php
@@ -5,6 +5,7 @@ namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Model;
 use Codeception\Test\Unit;
 use FondOfKudu\Shared\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConstants;
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Mapper\PriceProductScheduleMapper;
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Validator\SpecialPriceAttributesValidator;
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToCurrencyFacadeBridge;
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToPriceProductScheduleFacadeBridge;
 use FondOfKudu\Zed\ProductApiSchedulePriceImport\Dependency\Facade\ProductApiSchedulePriceImportToStoreFacadeBridge;
@@ -87,6 +88,11 @@ class SalePriceHandlerTest extends Unit
     protected MockObject|MoneyValueTransfer $moneyValueTransferMock;
 
     /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Validator\SpecialPriceAttributesValidator
+     */
+    protected MockObject|SpecialPriceAttributesValidator $specialPriceAttributesValidator;
+
+    /**
      * @var \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Model\SalePriceHandlerInterface
      */
     protected SalePriceHandlerInterface $salePriceHandler;
@@ -109,12 +115,14 @@ class SalePriceHandlerTest extends Unit
         $this->priceProductScheduleTransferMock = $this->createMock(PriceProductScheduleTransfer::class);
         $this->priceProductTransferMock = $this->createMock(PriceProductTransfer::class);
         $this->moneyValueTransferMock = $this->createMock(MoneyValueTransfer::class);
+        $this->specialPriceAttributesValidator = $this->createMock(SpecialPriceAttributesValidator::class);
 
         $this->salePriceHandler = new SalePriceHandler(
             $this->priceProductScheduleMapperMock,
             $this->priceProductScheduleFacadeMock,
             $this->currencyFacadeMock,
             $this->storeFacadeMock,
+            $this->specialPriceAttributesValidator,
             $this->productApiSchedulePriceImportRepositoryMock,
             $this->apiSchedulePriceImportConfigMock,
         );
@@ -133,17 +141,14 @@ class SalePriceHandlerTest extends Unit
                 ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO => '2024-12-31',
             ]);
 
-        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
-            ->method('getProductAttributeSalePrice')
-            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE);
-
-        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
-            ->method('getProductAttributeSalePriceFrom')
-            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM);
-
-        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
-            ->method('getProductAttributeSalePriceTo')
-            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO);
+        $this->specialPriceAttributesValidator->expects(static::atLeastOnce())
+            ->method('validate')
+            ->with([
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE => null,
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM => '2024-01-01',
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO => '2024-12-31',
+            ])
+            ->willReturn(false);
 
         $this->currencyFacadeMock->expects(static::never())
             ->method('getCurrent');
@@ -166,17 +171,14 @@ class SalePriceHandlerTest extends Unit
                 ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO => '2024-12-31',
             ]);
 
-        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
-            ->method('getProductAttributeSalePrice')
-            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE);
-
-        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
-            ->method('getProductAttributeSalePriceFrom')
-            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM);
-
-        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
-            ->method('getProductAttributeSalePriceTo')
-            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO);
+        $this->specialPriceAttributesValidator->expects(static::atLeastOnce())
+            ->method('validate')
+            ->with([
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE => '2999',
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM => '2024-01-01',
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO => '2024-12-31',
+            ])
+            ->willReturn(true);
 
         $this->currencyFacadeMock->expects(static::atLeastOnce())
             ->method('getCurrent')
@@ -238,6 +240,15 @@ class SalePriceHandlerTest extends Unit
                 ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM => '2024-01-01',
                 ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO => '2024-12-31',
             ]);
+
+        $this->specialPriceAttributesValidator->expects(static::atLeastOnce())
+            ->method('validate')
+            ->with([
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE => '2999',
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM => '2024-01-01',
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO => '2024-12-31',
+            ])
+            ->willReturn(true);
 
         $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
             ->method('getProductAttributeSalePrice')
@@ -340,17 +351,14 @@ class SalePriceHandlerTest extends Unit
                 ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO => '2024-12-31',
             ]);
 
-        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
-            ->method('getProductAttributeSalePrice')
-            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE);
-
-        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
-            ->method('getProductAttributeSalePriceFrom')
-            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM);
-
-        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
-            ->method('getProductAttributeSalePriceTo')
-            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO);
+        $this->specialPriceAttributesValidator->expects(static::atLeastOnce())
+            ->method('validate')
+            ->with([
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE => null,
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM => '2024-01-01',
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO => '2024-12-31',
+            ])
+            ->willReturn(false);
 
         $this->currencyFacadeMock->expects(static::never())
             ->method('getCurrent');
@@ -373,17 +381,14 @@ class SalePriceHandlerTest extends Unit
                 ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO => '2024-12-31',
             ]);
 
-        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
-            ->method('getProductAttributeSalePrice')
-            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE);
-
-        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
-            ->method('getProductAttributeSalePriceFrom')
-            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM);
-
-        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
-            ->method('getProductAttributeSalePriceTo')
-            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO);
+        $this->specialPriceAttributesValidator->expects(static::atLeastOnce())
+            ->method('validate')
+            ->with([
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE => '2999',
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM => '2024-01-01',
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO => '2024-12-31',
+            ])
+            ->willReturn(true);
 
         $this->currencyFacadeMock->expects(static::atLeastOnce())
             ->method('getCurrent')
@@ -445,6 +450,15 @@ class SalePriceHandlerTest extends Unit
                 ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM => '2024-01-01',
                 ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO => '2024-12-31',
             ]);
+
+        $this->specialPriceAttributesValidator->expects(static::atLeastOnce())
+            ->method('validate')
+            ->with([
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE => '2999',
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM => '2024-01-01',
+                ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO => '2024-12-31',
+            ])
+            ->willReturn(true);
 
         $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
             ->method('getProductAttributeSalePrice')

--- a/bundles/product-api-schedule-price-import/tests/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Validator/SpecialPriceAttributesValidatorTest.php
+++ b/bundles/product-api-schedule-price-import/tests/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Validator/SpecialPriceAttributesValidatorTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Validator;
+
+use Codeception\Test\Unit;
+use FondOfKudu\Shared\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConstants;
+use FondOfKudu\Zed\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class SpecialPriceAttributesValidatorTest extends Unit
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfKudu\Zed\ProductApiSchedulePriceImport\ProductApiSchedulePriceImportConfig
+     */
+    protected MockObject|ProductApiSchedulePriceImportConfig $apiSchedulePriceImportConfigMock;
+
+    /**
+     * @var SpecialPriceAttributesValidatorInterface
+     */
+    protected SpecialPriceAttributesValidatorInterface $validator;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        $this->apiSchedulePriceImportConfigMock = $this->createMock(ProductApiSchedulePriceImportConfig::class);
+        $this->validator = new SpecialPriceAttributesValidator($this->apiSchedulePriceImportConfigMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidateValid(): void
+    {
+        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
+            ->method('getProductAttributeSalePrice')
+            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE);
+
+        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
+            ->method('getProductAttributeSalePriceFrom')
+            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM);
+
+        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
+            ->method('getProductAttributeSalePriceTo')
+            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO);
+
+        static::assertTrue($this->validator->validate([
+            ProductApiSchedulePriceImportConstants::SPECIAL_PRICE => '2999',
+            ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM => '2023-01-01',
+            ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO => '2060-12-31',
+        ]));
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidateInvalidAttributeMissing(): void
+    {
+        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
+            ->method('getProductAttributeSalePrice')
+            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE);
+
+        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
+            ->method('getProductAttributeSalePriceFrom')
+            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM);
+
+        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
+            ->method('getProductAttributeSalePriceTo')
+            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO);
+
+        static::assertFalse($this->validator->validate([
+            ProductApiSchedulePriceImportConstants::SPECIAL_PRICE => null,
+            ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM => '2023-01-01',
+            ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO => '2060-12-31',
+        ]));
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidateInvalidSpecialPriceToIsInPast(): void
+    {
+        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
+            ->method('getProductAttributeSalePrice')
+            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE);
+
+        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
+            ->method('getProductAttributeSalePriceFrom')
+            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM);
+
+        $this->apiSchedulePriceImportConfigMock->expects(static::atLeastOnce())
+            ->method('getProductAttributeSalePriceTo')
+            ->willReturn(ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO);
+
+        static::assertFalse($this->validator->validate([
+            ProductApiSchedulePriceImportConstants::SPECIAL_PRICE => '2999',
+            ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_FROM => '2020-01-01',
+            ProductApiSchedulePriceImportConstants::SPECIAL_PRICE_TO => '2023-12-31',
+        ]));
+    }
+}

--- a/bundles/product-api-schedule-price-import/tests/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Validator/SpecialPriceAttributesValidatorTest.php
+++ b/bundles/product-api-schedule-price-import/tests/FondOfKudu/Zed/ProductApiSchedulePriceImport/Business/Validator/SpecialPriceAttributesValidatorTest.php
@@ -15,7 +15,7 @@ class SpecialPriceAttributesValidatorTest extends Unit
     protected MockObject|ProductApiSchedulePriceImportConfig $apiSchedulePriceImportConfigMock;
 
     /**
-     * @var SpecialPriceAttributesValidatorInterface
+     * @var \FondOfKudu\Zed\ProductApiSchedulePriceImport\Business\Validator\SpecialPriceAttributesValidatorInterface
      */
     protected SpecialPriceAttributesValidatorInterface $validator;
 

--- a/dandelion.json
+++ b/dandelion.json
@@ -48,7 +48,7 @@
     },
     "product-api-schedule-price-import": {
       "path": "bundles/product-api-schedule-price-import",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     "product-image-storage-connector": {
       "path": "bundles/product-image-storage-connector",


### PR DESCRIPTION
**Description**

**Issue:** A new scheduled price was being created upon saving a product, even when the special_price_date was in the past.

**Solution:** Implemented a check to ensure that a scheduled price is only created if the special_price_date is in the future. This prevents unnecessary and incorrect price schedules from being added for past dates.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207702351460916