### PR TITLE
fix: verified customer validator customer transfer null

### DIFF
--- a/bundles/verified-customer/src/FondOfKudu/Glue/VerifiedCustomer/Processor/Validator/VerifiedCustomerValidator.php
+++ b/bundles/verified-customer/src/FondOfKudu/Glue/VerifiedCustomer/Processor/Validator/VerifiedCustomerValidator.php
@@ -63,6 +63,10 @@ class VerifiedCustomerValidator implements VerifiedCustomerValidatorInterface
 
         $customerTransfer = $customerResponseTransfer->getCustomerTransfer();
 
+        if ($customerTransfer === null) {
+            return null;
+        }
+
         if ($customerTransfer->getRegistered() === null && $customerTransfer->getRegistrationKey() !== null) {
             return $this->createRestErrorCollection();
         }

--- a/bundles/verified-customer/tests/FondOfKudu/Glue/VerifiedCustomer/Processor/Validator/VerifiedCustomerValidatorTest.php
+++ b/bundles/verified-customer/tests/FondOfKudu/Glue/VerifiedCustomer/Processor/Validator/VerifiedCustomerValidatorTest.php
@@ -139,4 +139,28 @@ class VerifiedCustomerValidatorTest extends Unit
 
         $this->assertNull($result);
     }
+
+    /**
+     * @return void
+     */
+    public function testIsVerifiedReturnsNullWhenCustomerIsNull(): void
+    {
+        $this->requestMock->method('getRestUser')->willReturn(
+            (new RestUserTransfer())->setNaturalIdentifier('customer_reference'),
+        );
+
+        $customerTransfer = new CustomerTransfer();
+        $customerTransfer->setCustomerReference('customer_reference');
+        $customerTransfer->setRegistered('2021-01-01');
+        $customerTransfer->setRegistrationKey(null);
+
+        $customerResponseTransfer = new CustomerResponseTransfer();
+        $customerResponseTransfer->setCustomerTransfer(null);
+
+        $this->customerClientMock->method('findCustomerByReference')->willReturn($customerResponseTransfer);
+
+        $result = $this->validator->isVerified($this->requestMock);
+
+        $this->assertNull($result);
+    }
 }

--- a/dandelion.json
+++ b/dandelion.json
@@ -100,7 +100,7 @@
     },
     "verified-customer": {
       "path": "bundles/verified-customer",
-      "version": "1.0.0"
+      "version": "1.0.1"
     }
   },
   "vcs": {


### PR DESCRIPTION
This pull request includes changes to the `VerifiedCustomer` module to handle cases when the customer transfer is null and updates the module version. The most important changes include adding a null check in the `isVerified` method and a corresponding test case for this scenario.

Improvements to `VerifiedCustomer` module:

* [`bundles/verified-customer/src/FondOfKudu/Glue/VerifiedCustomer/Processor/Validator/VerifiedCustomerValidator.php`](diffhunk://#diff-e2aec194744e95be8dbd2d05760f23b1b5173a75a8f07461b78ed4c5d61f0c32R66-R69): Added a null check for `customerTransfer` in the `isVerified` method to handle cases when it is null.
* [`bundles/verified-customer/tests/FondOfKudu/Glue/VerifiedCustomer/Processor/Validator/VerifiedCustomerValidatorTest.php`](diffhunk://#diff-97f62976b9ecd9aff3639b8079f2e58579bb98b47cabeac53224b54b0136c2b8R142-R165): Added a new test case `testIsVerifiedReturnsNullWhenCustomerIsNull` to verify that the `isVerified` method returns null when `customerTransfer` is null.

Version update:

* [`dandelion.json`](diffhunk://#diff-7a956eb881ac6acdd79f76ca4dddd828abb5f97216f8992509673d941d853968L103-R103): Updated the version of the `verified-customer` module from `1.0.0` to `1.0.1`.